### PR TITLE
Add `accumulate_on_update` transformation and two accumulator functions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,15 @@
 # optinspect
 
-Inspect and debug optax gradient transformations.
+optinspect provides optax gradient transformation that leave updates unchanged but are useful for inspecting and debugging optimization algorithms.
 
 ## Printing Gradient and State Information
 
 - `print_on_update`: Print updates, parameters, or extra arguments without changing updates.
 - `print_before_after_update`: Print state information before and/or after updates.
+
+## Accumulating Gradient and State Information
+
+- `accumulate_on_update`: Accumulate updates, parameters, or extra arguments without channging updates.
 
 ## Applying Arbitrary Functions
 

--- a/optinspect/__init__.py
+++ b/optinspect/__init__.py
@@ -1,7 +1,15 @@
+from .accumulate import (
+    accumulate_cumulative_average,
+    accumulate_on_update,
+    accumulate_most_recent,
+)
 from .format_and_print import print_before_after_update, print_on_update
 from .util import before_after_update, is_traced, on_update
 
 __all__ = [
+    "accumulate_cumulative_average",
+    "accumulate_on_update",
+    "accumulate_most_recent",
     "before_after_update",
     "is_traced",
     "on_update",

--- a/optinspect/accumulate.py
+++ b/optinspect/accumulate.py
@@ -1,0 +1,126 @@
+import jax
+import optax
+from typing import Any, Callable, NamedTuple, Optional, Union
+from .util import is_traced
+
+
+def _make_key_func(key: Union[str, int, Callable]) -> Callable:
+    if isinstance(key, str):
+        return lambda **kwargs: kwargs[key]
+    elif callable(key):
+        return key
+    raise ValueError(f"`key` must be a string or callable but got {key}.")
+
+
+def accumulate_cumulative_average(
+    key: Union[str, Callable] = "updates",
+    period: Optional[int] = None,
+) -> Callable:
+    """
+    Accumulate the cumulative average.
+
+    Args:
+        key: Quantity to accumulate. If a string, accumulate a keyword argument. If a
+            callable with the same signature as
+            :meth:`~optax.GradientTransformationExtraArgs.update` (although only
+            accepting keyword arguments), accumulate the returned value.
+        period: Period after which the cumulative average resets.
+
+    Returns:
+        Accumulator function.
+    """
+    key_func = _make_key_func(key)
+
+    def _accumulate(
+        count: int,
+        value: Any,
+        updates: optax.Updates,
+        state: optax.OptState,
+        params: Optional[optax.Params] = None,
+        **extra_args: Any,
+    ) -> Any:
+        step = count % period if period else count
+        return jax.tree.map(
+            lambda old, new: (step * old + new) / (step + 1),
+            value,
+            key_func(updates=updates, state=state, params=params, **extra_args),
+        )
+
+    return _accumulate
+
+
+def accumulate_most_recent(key: Union[str, Callable] = "updates") -> Callable:
+    """
+    Accumulate the most recent value.
+
+    Args:
+        key: Quantity to accumulate. If a string, accumulate a keyword argument. If a
+            callable with the same signature as
+            :meth:`~optax.GradientTransformationExtraArgs.update` (although only
+            accepting keyword arguments), accumulate the returned value.
+
+    Returns:
+        Accumulator function.
+    """
+    key_func = _make_key_func(key)
+
+    def _accumulate(
+        count: int,
+        value: Any,
+        updates: optax.Updates,
+        state: optax.OptState,
+        params: Optional[optax.Params] = None,
+        **extra_args: Any,
+    ) -> Any:
+        return key_func(updates=updates, state=state, params=params, **extra_args)
+
+    return _accumulate
+
+
+class AccumulateOnUpdateState(NamedTuple):
+    count: int
+    value: Any
+
+
+def accumulate_on_update(
+    func: Callable, init: Any = None, *, skip_if_traced: bool = True
+) -> optax.GradientTransformationExtraArgs:
+    """
+    Accumulate updates, parameters, or extra arguments without channging updates.
+
+    Args:
+        func: Accumulator function, receiving the iteration number as its first
+            argument, previous accumulated value as its second argument, and
+            :code:`updates`, :code:`state`, :code:`params`, and unpacked
+            :code:`**extra_args` as keyword arguments.
+        init: Initial state of the accumulator, defaults to the argument passed to
+            :code:`init`.
+        skip_if_traced: Skip accumulation if any of the arguments passed to
+            :code`update` are traced.
+    """
+
+    # We don't use `optinspect.util.on_update` because we need to keep track of the
+    # accumulator state.
+    def init_func(params: optax.Params) -> AccumulateOnUpdateState:
+        return AccumulateOnUpdateState(0, params if init is None else init)
+
+    def update_func(
+        updates: optax.Updates,
+        state: AccumulateOnUpdateState,
+        params: Optional[optax.Params] = None,
+        **extra_args: Any,
+    ) -> tuple[optax.Updates, AccumulateOnUpdateState]:
+        skip = skip_if_traced and is_traced(state)
+        if not skip:
+            value = func(
+                state.count,
+                state.value,
+                updates=updates,
+                state=state,
+                params=params,
+                **extra_args,
+            )
+            state = AccumulateOnUpdateState(state.count + 1, value)
+        return updates, state
+
+    return optax.GradientTransformationExtraArgs(init_func, update_func)

--- a/optinspect/tests/test_accumulate.py
+++ b/optinspect/tests/test_accumulate.py
@@ -1,0 +1,31 @@
+from jax import numpy as jnp
+import optinspect
+import pytest
+from typing import Any, Callable
+
+
+@pytest.mark.parametrize(
+    "accumulate_func, expected",
+    [
+        (optinspect.accumulate_cumulative_average(), 4.5),
+        (optinspect.accumulate_cumulative_average(period=4), 8.5),
+        (optinspect.accumulate_most_recent(lambda **kwargs: kwargs["state"].count), 9),
+    ],
+)
+def test_accumulate(accumulate_func: Callable, expected: Any) -> None:
+    x = jnp.array(4.0)
+    optim = optinspect.accumulate_on_update(accumulate_func)
+    state = optim.init(x)
+
+    n = 10
+    for grad in jnp.arange(n):
+        updated, state = optim.update(grad, state, x)
+        assert jnp.allclose(updated, grad), "Gradient must be unchanged."
+
+    assert state.count == n
+    assert jnp.allclose(state.value, expected)
+
+
+def test_accumulate_invalid_key() -> None:
+    with pytest.raises(ValueError, match="must be a string or callable"):
+        optinspect.accumulate_cumulative_average(key=9)


### PR DESCRIPTION
This PR adds a gradient transformation to accumulate parameters, gradients, or extra arguments. Two accumulator functions are provided: `accumulate_cumulative_average` and `accumulate_most_recent`.